### PR TITLE
Polish topic quick infos a litte bit

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -11,8 +11,6 @@ require (
 	github.com/go-chi/chi v4.0.2+incompatible
 	github.com/gorilla/schema v1.1.0
 	github.com/kafka-owl/common v0.1.0
-	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/prometheus/client_golang v1.3.0
 	github.com/prometheus/common v0.7.0
 	github.com/valyala/fastjson v1.4.1

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -102,6 +102,7 @@ github.com/prometheus/common v0.7.0 h1:L+1lyG48J1zAQXA3RBX/nG/B3gjlHq0zTt2tlbJLy
 github.com/prometheus/common v0.7.0/go.mod h1:DjGbpBbp5NYNiECxcL/VnbXCCaQpKd3tt26CguLLsqA=
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
+github.com/prometheus/procfs v0.0.8 h1:+fpWZdT24pJBiqJdAwYBjPSk+5YmQzYNPYzQsdzLkt8=
 github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+GxbHq6oeK9A=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a h1:9ZKAASQSHhDYGoxY8uLVpewe1GDZ2vu2Tr/vTdVAkFQ=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=

--- a/frontend/src/components/pages/topic/Topic.Config.tsx
+++ b/frontend/src/components/pages/topic/Topic.Config.tsx
@@ -46,7 +46,6 @@ const markerIcon = <Icon type="highlight" theme="twoTone" twoToneColor="#1890ff"
 export const FavoritePopover = (configEntry: TopicConfigEntry, children: React.ReactNode) => {
 
     const name = configEntry.name;
-    console.log("popover: " + uiState.topicDetails.favConfigEntries);
     const favs = uiState.topicDetails.favConfigEntries;
     const isFav = favs.includes(name);
     const toggleFav = isFav

--- a/frontend/src/components/pages/topic/Topic.Config.tsx
+++ b/frontend/src/components/pages/topic/Topic.Config.tsx
@@ -46,6 +46,7 @@ const markerIcon = <Icon type="highlight" theme="twoTone" twoToneColor="#1890ff"
 export const FavoritePopover = (configEntry: TopicConfigEntry, children: React.ReactNode) => {
 
     const name = configEntry.name;
+    console.log("popover: " + uiState.topicDetails.favConfigEntries);
     const favs = uiState.topicDetails.favConfigEntries;
     const isFav = favs.includes(name);
     const toggleFav = isFav

--- a/frontend/src/components/pages/topic/Topic.QuickInfo.tsx
+++ b/frontend/src/components/pages/topic/Topic.QuickInfo.tsx
@@ -39,12 +39,13 @@ export const TopicQuickInfoStatistic = observer((p: { config: TopicConfigEntry[]
         <Statistic title='Size' value={prettyBytes(p.size)} style={statsStyle} />
 
         {
-            p.config
-                .filter(e => uiState.topicDetails.favConfigEntries.includes(e.name))
-                .map((e) =>
-                    FavoritePopover(e, (
+            uiState.topicDetails.favConfigEntries
+                .map(fce => p.config.find(tce => tce.name === fce))
+                .filter(tce => !!tce)
+                .map(tce =>
+                    FavoritePopover(tce!, (
                         <div style={statsStyle}>
-                            <Statistic title={(e.name)} value={FormatValue(e)} />
+                            <Statistic title={(tce!.name)} value={FormatValue(tce!)} />
                         </div>
                     ))
                 )

--- a/frontend/src/components/pages/topic/Topic.QuickInfo.tsx
+++ b/frontend/src/components/pages/topic/Topic.QuickInfo.tsx
@@ -32,7 +32,6 @@ const statsStyle: CSSProperties = { margin: 0, marginRight: '2em', padding: '.2e
 // todo: rename QuickInfo
 export const TopicQuickInfoStatistic = observer((p: { config: TopicConfigEntry[], size: number }) => {
     const cleanupPolicy = p.config.find(e => e.name === 'cleanup.policy');
-
     uiState.topicDetails.setAvailableFavs(cleanupPolicy ? cleanupPolicy.value : "");
 
     return <Row type="flex" style={{ marginBottom: '1em' }}>

--- a/frontend/src/components/pages/topic/Topic.QuickInfo.tsx
+++ b/frontend/src/components/pages/topic/Topic.QuickInfo.tsx
@@ -30,18 +30,25 @@ const InputGroup = Input.Group;
 const statsStyle: CSSProperties = { margin: 0, marginRight: '2em', padding: '.2em' };
 
 // todo: rename QuickInfo
-export const TopicQuickInfoStatistic = observer((p: { config: TopicConfigEntry[], size: number }) =>
-    <Row type="flex" style={{ marginBottom: '1em' }}>
+export const TopicQuickInfoStatistic = observer((p: { config: TopicConfigEntry[], size: number }) => {
+    const cleanupPolicy = p.config.find(e => e.name === 'cleanup.policy');
 
-        <Statistic title='Size' value={prettyBytes(p.size)} style={statsStyle}/>
+    uiState.topicDetails.setAvailableFavs(cleanupPolicy ? cleanupPolicy.value : "");
 
-        {p.config.filter(e => uiState.topicDetails.favConfigEntries.includes(e.name)).map((e) =>
-            FavoritePopover(e, (
-                <div style={statsStyle}>
-                    <Statistic title={(e.name)} value={FormatValue(e)} />
-                </div>
-            ))
-        )
+    return <Row type="flex" style={{ marginBottom: '1em' }}>
+
+        <Statistic title='Size' value={prettyBytes(p.size)} style={statsStyle} />
+
+        {
+            p.config
+                .filter(e => uiState.topicDetails.favConfigEntries.includes(e.name))
+                .map((e) =>
+                    FavoritePopover(e, (
+                        <div style={statsStyle}>
+                            <Statistic title={(e.name)} value={FormatValue(e)} />
+                        </div>
+                    ))
+                )
         }
     </Row>
-)
+})

--- a/frontend/src/state/uiState.ts
+++ b/frontend/src/state/uiState.ts
@@ -46,7 +46,6 @@ export class TopicDetailsSettings {
                 );
                 break;
         }
-        console.log("setAvailableFavs: " + this.favConfigEntries);
     }
 }
 

--- a/frontend/src/state/uiState.ts
+++ b/frontend/src/state/uiState.ts
@@ -15,22 +15,30 @@ export class TopicDetailsSettings {
     @observable activeTabKey: string | undefined = undefined;
     @observable favConfigEntries: Array<string> = ['cleanup.policy', 'segment.bytes', 'segment.ms'];
 
+    private pushIfNotPresent(...items: string[]): void {
+        items.forEach(item => {
+            if (!this.favConfigEntries.find(i => i === item)) {
+                this.favConfigEntries.push(item);
+            }
+        });
+    }
+
     public setAvailableFavs(cleanupPolicy: string): void {
         switch (cleanupPolicy) {
             case "delete":
-                this.favConfigEntries.push(
+                this.pushIfNotPresent(
                     'retention.ms',
                     'retention.bytes',
                 );
                 break;
             case "compact":
-                this.favConfigEntries.push(
+                this.pushIfNotPresent(
                     'min.cleanable.dirty.ratio',
                     'delete.retention.ms',
                 );
                 break;
             case "compact,delete":
-                this.favConfigEntries.push(
+                this.pushIfNotPresent(
                     'retention.ms',
                     'retention.bytes',
                     'min.cleanable.dirty.ratio',
@@ -38,6 +46,7 @@ export class TopicDetailsSettings {
                 );
                 break;
         }
+        console.log("setAvailableFavs: " + this.favConfigEntries);
     }
 }
 

--- a/frontend/src/state/uiState.ts
+++ b/frontend/src/state/uiState.ts
@@ -13,7 +13,32 @@ export class TopicDetailsSettings {
 
     // per topic
     @observable activeTabKey: string | undefined = undefined;
-    @observable favConfigEntries: Array<string> = ['cleanup.policy', 'retention.ms', 'segment.bytes', 'segment.ms'];
+    @observable favConfigEntries: Array<string> = ['cleanup.policy', 'segment.bytes', 'segment.ms'];
+
+    public setAvailableFavs(cleanupPolicy: string): void {
+        switch (cleanupPolicy) {
+            case "delete":
+                this.favConfigEntries.push(
+                    'retention.ms',
+                    'retention.bytes',
+                );
+                break;
+            case "compact":
+                this.favConfigEntries.push(
+                    'min.cleanable.dirty.ratio',
+                    'delete.retention.ms',
+                );
+                break;
+            case "compact,delete":
+                this.favConfigEntries.push(
+                    'retention.ms',
+                    'retention.bytes',
+                    'min.cleanable.dirty.ratio',
+                    'delete.retention.ms',
+                );
+                break;
+        }
+    }
 }
 
 class UIState {


### PR DESCRIPTION
A user of this lovely tool suggested this, so I created this PR to improve topic quick infos a little bit.

A topic can have one of three possible cleanup policies: delete, compact and a combination of both.
Depending on the policy some topic configuration entries are important while others are irrelevant.

This PR aims at displaying the relevant configs for the different policies in a defined order. Adding or removing favorites should still be working.

Let me know what you think. I might have broken some conventions or made React rookie mistakes. ;)